### PR TITLE
remove source dependency on vision_opencv

### DIFF
--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -26,11 +26,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
       - uses: ros-tooling/setup-ros@v0.3
         with:
           use-ros2-testing: true
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: rolling
-          vcs-repo-file-url: dependencies.repos

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,5 +1,0 @@
-repositories:
-  vision_opencv:
-    type: git
-    url: https://github.com/ros-perception/vision_opencv.git
-    version: rolling


### PR DESCRIPTION
Release for vision_opencv has been made upstream in https://github.com/ros/rosdistro/pull/34598.
Related: #9