### PR TITLE
Fix buildfarm failure

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,11 +11,10 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>ament_cmake_pytest</buildtool_depend>
 
-  <depend>sensor_msgs</depend>
-  <depend>qtbase5-dev</depend>
   <depend>cv_bridge</depend>
-
-  <exec_depend>python_qt_binding</exec_depend>
+  <depend>python_qt_binding</depend>
+  <depend>qtbase5-dev</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Tries to solve #26

I believe this is coming from python_qt_binding being listed as an <exec_depend>. It seems to make sense to have it as an exec_depend because it's only used in the python code, but it is exported as a dependency (``ament_export_dependencies(python_qt_binding)``), and maybe this needs it to be a <depend> tag.

This PR changes python_qt_binding from exec_depend to depend, because it is being used in CMakeLists.txt. Also reorganizes dependencies in alphabetical order, in package.xml

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>